### PR TITLE
Require symfony/yaml >=2.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 php:
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.1",
         "phpunit/phpunit": "^6.5",
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3",
+        "symfony/yaml": ">=2.0.5"
     },
     "autoload": {
         "psr-4": { "Chadicus\\Util\\": "src" }


### PR DESCRIPTION
Fixes #38

When running build with `--prefer-lowest`  symfony/yaml v2.0.4 is installed. This version does not contain an autoload directive in its composer file.  
The autoload config was added in v2.0.5
